### PR TITLE
(feat) Support running on NFS folders

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,12 @@ services:
       - type: volume
         source: minio-buckets
         target: /test-data
+      - type: volume
+        source: simulate-nfs
+        target: /nfs-1
+      - type: volume
+        source: simulate-nfs
+        target: /nfs-2
     networks:
       ecs_emulation:
         ipv4_address: '169.254.170.3'
@@ -52,6 +58,7 @@ services:
         ipv4_address: '169.254.170.2'
 volumes:
   minio-buckets:
+  simulate-nfs:
 
 networks:
   ecs_emulation:


### PR DESCRIPTION
This is so we can have a setup where we have mutiple mobius3 clients running on a folder shared on NFS, and synced to and from S3.

Note that we're not expecting inotify events to be triggered for remote changes via NFS: just local changes.