### PR TITLE
feat: don't attempt to upload existing local files on start, and don't delete local files until we have downloaded

### DIFF
--- a/mobius3.py
+++ b/mobius3.py
@@ -411,7 +411,6 @@ def Syncer(
         ]
         start_inotify(logger, upload=False)
         await list_and_schedule_downloads(logger)
-        await download_job_queue.join()
         download_manager_task = asyncio.create_task(
             download_manager(get_logger_adapter({'mobius3_component': 'download'}))
         )
@@ -974,7 +973,6 @@ def Syncer(
                 raise
             except Exception:
                 logger.exception('Failed to list files')
-            await download_job_queue.join()
             await asyncio.sleep(download_interval)
 
     async def list_and_schedule_downloads(logger):
@@ -996,6 +994,8 @@ def Syncer(
 
             logger.info('Scheduling download: %s', path)
             schedule_download(logger, path)
+
+        await download_job_queue.join()
 
         full_paths = set(directory / path for path, _ in path_etags)
         for root, dirs, files in os.walk(directory, topdown=False):

--- a/mobius3.py
+++ b/mobius3.py
@@ -409,7 +409,7 @@ def Syncer(
             asyncio.create_task(process_jobs(download_job_queue))
             for i in range(0, concurrent_downloads)
         ]
-        start_inotify(logger)
+        start_inotify(logger, upload=False)
         await list_and_schedule_downloads(logger)
         await download_job_queue.join()
         download_manager_task = asyncio.create_task(
@@ -417,7 +417,7 @@ def Syncer(
         )
         logger.info('Finished starting')
 
-    def start_inotify(logger):
+    def start_inotify(logger, upload):
         nonlocal wds_to_path
         nonlocal meta
         nonlocal etags
@@ -442,7 +442,7 @@ def Syncer(
 
         loop.add_reader(fd, _read_events)
         watch_directory(download_directory, DOWNLOAD_WATCH_MASK)
-        watch_and_upload_directory(logger, directory, WATCH_MASK)
+        watch_directory_recursive(logger, directory, WATCH_MASK, upload)
 
     async def stop():
         # Make every effort to read all incoming events and finish the queue
@@ -479,27 +479,29 @@ def Syncer(
         # Notify any waiting watchers
         directory_watch_events.setdefault(path, default=asyncio.Event()).set()
 
-    def watch_and_upload_directory(logger, path, mask):
+    def watch_directory_recursive(logger, path, mask, upload):
         watch_directory(path, mask)
 
         if PurePosixPath(path) not in [directory, directory / download_directory]:
             try:
                 del ignore_next_directory_upload[path]
             except KeyError:
-                logger.info('Scheduling upload directory: %s', path)
-                schedule_upload_directory(logger, path)
+                if upload:
+                    logger.info('Scheduling upload directory: %s', path)
+                    schedule_upload_directory(logger, path)
 
         # By the time we've added a watcher, files or subdirectories may have
         # already been created
         for root, dirs, files in os.walk(path):
             if PurePosixPath(root) == directory / download_directory:
                 continue
-            for file in files:
-                logger.info('Scheduling upload: %s', PurePosixPath(root) / file)
-                schedule_upload(logger, PurePosixPath(root) / file)
+            if upload:
+                for file in files:
+                    logger.info('Scheduling upload: %s', PurePosixPath(root) / file)
+                    schedule_upload(logger, PurePosixPath(root) / file)
 
             for d in dirs:
-                watch_and_upload_directory(logger, PurePosixPath(root) / d, mask)
+                watch_directory_recursive(logger, PurePosixPath(root) / d, mask, upload)
 
     def remote_delete_directory(logger, path):
         # Directory nesting not likely to be large
@@ -572,7 +574,7 @@ def Syncer(
     def handle__overflow__IN_Q_OVERFLOW(logger, _, __, ___):
         logger.warning('IN_Q_OVERFLOW. Restarting')
         stop_inotify()
-        start_inotify(logger)
+        start_inotify(logger, upload=True)
 
     def handle__flush__IN_CREATE(logger, _, __, path):
         flush = flushes[path]
@@ -594,7 +596,7 @@ def Syncer(
             schedule_upload(logger, path)
 
     def handle__dir__IN_CREATE(logger, _, __, path):
-        watch_and_upload_directory(logger, path, WATCH_MASK)
+        watch_directory_recursive(logger, path, WATCH_MASK, upload=True)
 
     def handle__file__IN_DELETE(logger, _, __, path):
         try:
@@ -648,7 +650,7 @@ def Syncer(
         schedule_delete(logger, path)
 
     def handle__dir__IN_MOVED_TO(logger, _, __, path):
-        watch_and_upload_directory(logger, path, WATCH_MASK)
+        watch_directory_recursive(logger, path, WATCH_MASK, upload=True)
 
     def handle__file__IN_MOVED_TO(logger, _, cookie, path):
         bump_content_version(path)

--- a/mobius3.py
+++ b/mobius3.py
@@ -479,6 +479,7 @@ def Syncer(
         directory_watch_events.setdefault(path, default=asyncio.Event()).set()
 
     def watch_directory_recursive(logger, path, mask, upload):
+        logger.info('Watching directory: %s, with upload: %s', path, upload)
         watch_directory(path, mask)
 
         if PurePosixPath(path) not in [directory, directory / download_directory]:

--- a/test.py
+++ b/test.py
@@ -612,6 +612,71 @@ class TestIntegration(unittest.TestCase):
         self.assertFalse(os.path.exists(f'/s3-home-folder/{dirname_1}'))
 
     @async_test
+    async def test_delete_existing_file_after_initial_download(self):
+        delete_dir = create_directory('/s3-home-folder')
+        self.add_async_cleanup(delete_dir)
+
+        # This _should_ end up deleted, but not until we've saved the remote
+        # files locally
+        filename_local = str(uuid.uuid4())
+        with open(f'/s3-home-folder/{filename_local}', 'wb') as file:
+            file.write(b'some-local-bytes')
+
+        # Ensure the file has not been modified within local_modification_persistance
+        await asyncio.sleep(1)
+
+        start, stop = Syncer(
+            '/s3-home-folder', 'my-bucket', 'http://localhost:8080/{}/', 'us-east-1',
+            local_modification_persistance=1,
+        )
+        self.add_async_cleanup(stop)
+
+        filename_remote = str(uuid.uuid4())
+
+        async def handle_list(_):
+            return web.Response(status=200, body=f'''<?xml version="1.0" encoding="UTF-8"?>
+                <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                    <Contents>
+                        <Key>{filename_remote}</Key>
+                        <ETag>&quot;fba9dede5f27731c9771645a39863328&quot;</ETag>
+                    </Contents>
+                </ListBucketResult>'''.encode()
+                                )
+
+        async def handle_file(_):
+            await asyncio.sleep(7)
+            return web.Response(status=200, headers={
+                'last-modified': 'Fri, 10 May 2019 06:53:17 GMT',
+                'etag': '"fba9dede5f27731c9771645a39863328"',
+            }, body=b'some-remote-bytes')
+
+        app = web.Application()
+        app.add_routes([
+            web.get(f'/my-bucket/', handle_list),
+            web.get(f'/my-bucket/{filename_remote}', handle_file),
+        ])
+        runner = web.AppRunner(app)
+        await runner.setup()
+        self.add_async_cleanup(runner.cleanup)
+        site = web.TCPSite(runner, '0.0.0.0', 8080)
+        await site.start()
+
+        asyncio.create_task(start())
+
+        # We have a slow initial download, during which the existing file
+        # that will eventually be deleted, should remain...
+        for _ in range(0, 4):
+            self.assertTrue(os.path.exists(f'/s3-home-folder/{filename_local}'))
+            self.assertFalse(os.path.exists(f'/s3-home-folder/{filename_remote}'))
+            await asyncio.sleep(1)
+
+        await asyncio.sleep(4)
+
+        # And then after the download, the existing file should be deleted
+        self.assertFalse(os.path.exists(f'/s3-home-folder/{filename_local}'))
+        self.assertTrue(os.path.exists(f'/s3-home-folder/{filename_remote}'))
+
+    @async_test
     async def test_nested_delete_downloaded_directory(self):
         delete_dir = create_directory('/s3-home-folder')
         self.add_async_cleanup(delete_dir)


### PR DESCRIPTION
Regarding upload:
- When run not on EFS, the folder would be empty, and no need to upload anything.
- When run on EFS, the source of truth would be S3. Say, files could have been uploaded using Your files. They should not be overridden by files in EFS.

Regarding the delete:
- When run not on EFS, the folder would be empty, so there are no local files to worry about in terms of when there are/are not deleted
- When run on EFS, the initial download from S3 could take a while, so we make sure we don't delete any local files until after this has happened