### PR TITLE
feat: reduce API calls in case where there is no folder object in files

### DIFF
--- a/mobius3.py
+++ b/mobius3.py
@@ -1101,6 +1101,11 @@ def Syncer(
         await download_job_queue.join()
 
         full_paths = set(directory / path for path, _ in path_etags)
+        full_paths_all_parents = set(
+            parent
+            for path, _ in path_etags
+            for parent in (directory / path).parents
+        )
         for root, dirs, files in os.walk(directory, topdown=False):
             for file in files:
                 full_path = PurePosixPath(root) / file
@@ -1145,6 +1150,7 @@ def Syncer(
                 if (
                         exclude_local.match(str(full_path)) or
                         full_path in full_paths or
+                        full_path in full_paths_all_parents or
                         is_dir_pull_blocked(full_path) or
                         full_path == directory / download_directory
                 ):


### PR DESCRIPTION
If we have files in a folder (or prefix) but with no folder object in S3 (so file ending in "/"), then there will be a needless API call to S3 for the existance of a the root object. This will return a 404, and then an attempt will be made to delete the local folder.

It's not the end of the world, but in some configs, too many 404s are suspicious, so this should help reduce the noise.