### PR TITLE
feat: Adding the ability to see log start up time

### DIFF
--- a/mobius3.py
+++ b/mobius3.py
@@ -20,6 +20,7 @@ import signal
 import ssl
 import stat
 import sys
+import time
 import uuid
 import urllib.parse
 from pathlib import (
@@ -482,6 +483,7 @@ def Syncer(
         nonlocal upload_tasks
         nonlocal download_tasks
         nonlocal download_manager_task
+        start_time = time.monotonic()
         try:
             os.mkdir(directory / download_directory)
         except FileExistsError:
@@ -499,7 +501,8 @@ def Syncer(
         download_manager_task = asyncio.create_task(
             download_manager(get_logger_adapter({'mobius3_component': 'download'}))
         )
-        logger.info('Finished starting')
+        end_time = time.monotonic()
+        logger.info('Finished starting: %s seconds', end_time - start_time)
 
     def start_inotify(logger, upload):
         nonlocal wds_to_path


### PR DESCRIPTION
We have added in the start_time and end_time, using these we can see the log startup time.

This is so we can better monitor start up time but also as a stepping stone to sending metris to cloud watch.