### PR TITLE
fix: convert request methods to be string rather than a byte string

### DIFF
--- a/mobius3.py
+++ b/mobius3.py
@@ -291,7 +291,7 @@ def get_credentials_from_ecs_endpoint():
 
         if now > expiration:
             response = await client.request(
-                b'GET',
+                'GET',
                 'http://169.254.170.2' + os.environ['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI']
             )
             creds = json.loads(response.content)
@@ -978,7 +978,7 @@ def Syncer(
             set_etag(path, headers)
 
         await locked_request(
-            logger, b'PUT', path, file_key_for_path(path), content=content,
+            logger, 'PUT', path, file_key_for_path(path), content=content,
             get_headers=lambda: (
                 ('content-length', content_length),
             ) + data,
@@ -1007,7 +1007,7 @@ def Syncer(
 
         key = file_key_for_path(path)
         await locked_request(
-            logger, b'PUT', path, key,
+            logger, 'PUT', path, key,
             cont=lambda: meta[path] != data,
             get_headers=lambda: data + (
                 ('x-amz-copy-source', f'/{bucket}/{key}'),
@@ -1026,7 +1026,7 @@ def Syncer(
             raise FileContentChanged(path)
 
         await locked_request(
-            logger, b'PUT', path, dir_key_for_path(path),
+            logger, 'PUT', path, dir_key_for_path(path),
             get_headers=lambda: (
                 ('content-length', '0'),
                 ('x-amz-meta-mtime', mtime),
@@ -1050,7 +1050,7 @@ def Syncer(
         if content_version_current != content_version_original:
             raise FileContentChanged(path)
 
-        await locked_request(logger, b'DELETE', path, file_key_for_path(path))
+        await locked_request(logger, 'DELETE', path, file_key_for_path(path))
 
     async def delete_directory(logger, path):
         logger.info('Deleting directory %s', path)
@@ -1058,7 +1058,7 @@ def Syncer(
         if os.path.isdir(path):
             raise FileContentChanged(path)
 
-        await locked_request(logger, b'DELETE', path, dir_key_for_path(path))
+        await locked_request(logger, 'DELETE', path, dir_key_for_path(path))
 
     def file_key_for_path(path):
         return prefix + str(path.relative_to(directory))
@@ -1077,7 +1077,7 @@ def Syncer(
                 return
             remote_url = bucket_url + key
             headers = get_headers()
-            logger.debug('%s %s %s', method.decode(), remote_url, headers)
+            logger.debug('%s %s %s', method, remote_url, headers)
             response = await client.request(method, remote_url, headers=get_headers(), content=content, auth=auth)
             logger.debug('%s %s', response.status_code, response.headers)
 
@@ -1138,7 +1138,7 @@ def Syncer(
                 # Since walking the filesystem can take time we might have a new file that we have
                 # recently uploaded that was not present when we request the original file list.
                 path = full_path.relative_to(directory)
-                response = await client.request(b'HEAD', bucket_url + prefix + str(path), auth=auth)
+                response = await client.request('HEAD', bucket_url + prefix + str(path), auth=auth)
                 if response.status_code != 404:
                     continue
 
@@ -1175,7 +1175,7 @@ def Syncer(
                     continue
 
                 path = full_path.relative_to(directory)
-                response = await client.request(b'HEAD', bucket_url + prefix + str(path) + '/', auth=auth)
+                response = await client.request('HEAD', bucket_url + prefix + str(path) + '/', auth=auth)
                 if response.status_code != 404:
                     continue
 
@@ -1204,7 +1204,7 @@ def Syncer(
 
             logger.info('Downloading: %s', full_path)
 
-            async with client.stream(b'GET', bucket_url + prefix + path, auth=auth) as response:
+            async with client.stream('GET', bucket_url + prefix + path, auth=auth) as response:
                 if response.status_code != 200:
                     await buffered(response.aiter_bytes())  # Fetch all bytes and return to pool
                     raise Exception(response.status_code)
@@ -1334,7 +1334,7 @@ def Syncer(
                 ('list-type', '2'),
                 ('prefix', prefix),
             ) + extra_query_items
-            response = await client.request(b'GET', bucket_url, params=query, auth=auth)
+            response = await client.request('GET', bucket_url, params=query, auth=auth)
             if response.status_code != 200:
                 raise Exception(response.status_code, response.content)
 

--- a/test.py
+++ b/test.py
@@ -2570,13 +2570,13 @@ async def get_credentials_from_environment(_):
 
 
 async def object_response(client, key, bucket='my-bucket'):
-    return await client.request(b'GET', f'https://minio:9000/{bucket}/{key}', auth=AWSAuth(
+    return await client.request('GET', f'https://minio:9000/{bucket}/{key}', auth=AWSAuth(
         service='s3', region='us-east-1', client=client, get_credentials=get_credentials_from_environment
     ))
 
 
 async def delete_object(client, key):
-    return await client.request(b'DELETE', f'https://minio:9000/my-bucket/{key}', auth=AWSAuth(
+    return await client.request('DELETE', f'https://minio:9000/my-bucket/{key}', auth=AWSAuth(
         service='s3', region='us-east-1', client=client, get_credentials=get_credentials_from_environment
     ))
 
@@ -2587,7 +2587,7 @@ async def put_body(client, key, body):
         service='s3', region='us-east-1', client=client, get_credentials=get_credentials_from_environment,
         content_hash=content_hash
     )
-    return await client.request(b'PUT', f'https://minio:9000/my-bucket/{key}', headers=(
+    return await client.request('PUT', f'https://minio:9000/my-bucket/{key}', headers=(
         ('content-length', str(len(body))),
     ), content=hashed_content, auth=auth)
 
@@ -2637,7 +2637,7 @@ async def set_temporary_creds(client):
     content_hash, hashed_content = get_content_hash(request_body_bytes)
     auth = AWSAuth(service='sts', region='us-east-1', client=client, get_credentials=new_user_creds, content_hash=content_hash)
     response = await client.request(
-        b'POST', 'https://minio:9000/',
+        'POST', 'https://minio:9000/',
         headers=(
             ('content-type', 'application/x-www-form-urlencoded; charset=utf-8'),
             ('content-length', str(len(request_body_bytes))),
@@ -2658,7 +2658,7 @@ async def set_temporary_creds(client):
 
     request_content_bytes = json.dumps(creds).encode('utf-8')
     await client.request(
-        b'POST', 'http://169.254.170.2/creds', content=streamed(request_content_bytes), headers=(
+        'POST', 'http://169.254.170.2/creds', content=streamed(request_content_bytes), headers=(
             ('content-length', str(len(request_content_bytes))),
         ))
     return creds


### PR DESCRIPTION
This PR converts all byte string request methods to string, since it fails in recent version of `httpx`