### PR TITLE
fix: status_code to be an attribute of response object

### DIFF
--- a/mobius3.py
+++ b/mobius3.py
@@ -1082,7 +1082,7 @@ def Syncer(
             logger.debug('%s %s', response.status_code, response.headers)
 
             if response.status_code not in [200, 204]:
-                raise Exception(status_code, content)
+                raise Exception(response.status_code, content)
 
             on_done(path, response.headers)
 


### PR DESCRIPTION
`status_code` used in Exception statement in `locked_request` should be an attribute of response object